### PR TITLE
Update referenced tag

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "u-boot"]
 	path = u-boot
 	url = git@github.com:u-boot/u-boot.git
-	branch = v2026.01
+	branch = v2026.04
 [submodule "trusted-firmware-a"]
 	path = trusted-firmware-a
 	url = https://github.com/TrustedFirmware-A/trusted-firmware-a


### PR DESCRIPTION
The pinning was updated in https://github.com/dbast/qnap-ts-433-bootloader-builder/pull/40 but the tag increment was missing.